### PR TITLE
Use LibWally descriptors

### DIFF
--- a/NthKey/Model/DataManager.swift
+++ b/NthKey/Model/DataManager.swift
@@ -234,6 +234,7 @@ extension DataManager {
                 wallet.network = WalletNetwork.valueFromNetwork(network).int16Value
             }
             wallet.receive_descriptor = descriptor
+            let desc = try! Descriptor(descriptor, network)
 
             if let label = jsonResult["label"] as? String {
                 wallet.label = label
@@ -249,17 +250,9 @@ extension DataManager {
             }
 
             for idx in 0..<1000 {
-                let pubKeys = receivePublicHDkeys.map {key -> PubKey in
-                    let childKey: HDKey = try! key.derive(String(idx))
-                    return childKey.pubKey
-                }
-
-                let scriptPubKey = ScriptPubKey(multisig: pubKeys, threshold: UInt(threshold))
-                let receiveAddress = Address(scriptPubKey, network)!
-
                 let item = AddressEntity(context: store.container.viewContext)
                 item.receiveIndex = Int32(idx)
-                item.address = receiveAddress.description
+                item.address = try! desc.getAddress(UInt32(idx)).description
 
                 wallet.addToAddresses(item)
             }


### PR DESCRIPTION
Depends on https://github.com/Sjors/libwally-swift/pull/57

This switches the address list view to use the new libwally-core functionality for deriving an address from a descriptor.

We still need https://github.com/Sjors/output-descriptors-swift to process the wallet descriptor, in order to find out the cosigner keys and threshold value. But it should be straight-forward to expose that (currently internal) functionality in libwally-core.