### PR TITLE
Bump libwally-swift to v0.0.7

### DIFF
--- a/NthKey/Model/DataManager.swift
+++ b/NthKey/Model/DataManager.swift
@@ -164,11 +164,6 @@ extension DataManager {
                 return
             }
 
-            guard let pathForDerive = BIP32Path("0") else {
-                completion(.failure(.wrongCosigner))
-                return
-            }
-
             var receivePublicHDkeys: [HDKey] = []
             var hdKeys: [(ExtendedKey, HDKey)] = []
             desc.extendedKeys.forEach { key in
@@ -177,8 +172,8 @@ extension DataManager {
                         completion(.failure(.wrongCosigner))
                         return
                     }
-                    // ourself key
-                    receivePublicHDkeys.append(try! selfKey.derive(pathForDerive))
+                    // our key
+                    receivePublicHDkeys.append(try! selfKey.derive("0"))
                     return
                 }
                 let extendedKey = Data(base58: key.xpub)!
@@ -195,7 +190,7 @@ extension DataManager {
                 }
                 hdKeys.append((key, aKey))
                 // cosigners keys
-                receivePublicHDkeys.append(try! aKey.derive(pathForDerive))
+                receivePublicHDkeys.append(try! aKey.derive("0"))
             }
 
             // Checking co-signers network
@@ -248,15 +243,14 @@ extension DataManager {
                 let signer = CosignerEntity(context: store.container.viewContext)
                 signer.name = ""
                 signer.fingerprint = Data(key.fingerprint)
-                signer.derivation = BIP32Path(key.origin)?.description
+                signer.derivation = key.origin.description
                 signer.xpub = hdKey.description
                 wallet.addToCosigners(signer)
             }
 
             for idx in 0..<1000 {
                 let pubKeys = receivePublicHDkeys.map {key -> PubKey in
-                    let path = try! BIP32Path(idx, relative: true)
-                    let childKey: HDKey = try! key.derive(path)
+                    let childKey: HDKey = try! key.derive(String(idx))
                     return childKey.pubKey
                 }
 

--- a/NthKey/Model/SeedManager.swift
+++ b/NthKey/Model/SeedManager.swift
@@ -71,7 +71,7 @@ struct SeedManager {
         let masterKey = HDKey(seedHex, network)!
         assert(masterKey.fingerprint == fingerprint)
 
-        let path = BIP32Path("m/48h/\(network == .mainnet ? "0h" : "1h")/0h/2h")!
+        let path = "m/48h/\(network == .mainnet ? "0h" : "1h")/0h/2h"
         let account = try! masterKey.derive(path)
 
         // Specter compatible JSON format:

--- a/NthKey/Model/Signer.swift
+++ b/NthKey/Model/Signer.swift
@@ -12,11 +12,11 @@ import LibWally
 public class Signer: NSObject, Identifiable {
     
     public let fingerprint: Data
-    public let derivation: BIP32Path
+    public let derivation: String
     public let hdKey: HDKey // TODO: store derivation and fingerprint in HDKey?
     public let name: String
     
-    public init(fingerprint: Data, derivation: BIP32Path, hdKey: HDKey, name: String) {
+    public init(fingerprint: Data, derivation: String, hdKey: HDKey, name: String) {
         self.fingerprint = fingerprint
         self.name = name
         self.derivation = derivation
@@ -30,7 +30,7 @@ public class Signer: NSObject, Identifiable {
         let masterKey = HDKey(seedHex, network)!
         assert(masterKey.fingerprint == fingerprint)
         
-        let path = BIP32Path("m/48h/\(network == .mainnet ? "0h" : "1h")/0h/2h")!
+        let path = "m/48h/\(network == .mainnet ? "0h" : "1h")/0h/2h"
         let ourKey = try! masterKey.derive(path)
 
         return Signer(fingerprint: fingerprint, derivation: path, hdKey: ourKey, name: "NthKey")

--- a/Podfile
+++ b/Podfile
@@ -5,7 +5,7 @@ target 'NthKey' do
   # Comment the next line if you don't want to use dynamic frameworks
   use_frameworks!
 
-  pod 'LibWally', :git => 'https://github.com/sjors/LibWally-Swift.git', :tag => "v0.0.6", :submodules => true
+  pod 'LibWally', :git => 'https://github.com/jurvis/libwally-swift.git', :branch => "jurvis/cleanup-build-script-2", :submodules => true
   pod 'OutputDescriptors', :git => 'https://github.com/sjors/output-descriptors-swift.git', :tag => "v0.0.2"
 
   target 'NthKeyTests' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -3,31 +3,31 @@ PODS:
   - OutputDescriptors (0.0.1)
 
 DEPENDENCIES:
-  - LibWally (from `https://github.com/sjors/LibWally-Swift.git`, tag `v0.0.6`)
+  - LibWally (from `https://github.com/jurvis/libwally-swift.git`, branch `jurvis/cleanup-build-script-2`)
   - OutputDescriptors (from `https://github.com/sjors/output-descriptors-swift.git`, tag `v0.0.2`)
 
 EXTERNAL SOURCES:
   LibWally:
-    :git: https://github.com/sjors/LibWally-Swift.git
+    :branch: jurvis/cleanup-build-script-2
+    :git: https://github.com/jurvis/libwally-swift.git
     :submodules: true
-    :tag: v0.0.6
   OutputDescriptors:
     :git: https://github.com/sjors/output-descriptors-swift.git
     :tag: v0.0.2
 
 CHECKOUT OPTIONS:
   LibWally:
-    :git: https://github.com/sjors/LibWally-Swift.git
+    :commit: 5f52df6cda2e3c78a1770eaf715ffdacfac1ea5b
+    :git: https://github.com/jurvis/libwally-swift.git
     :submodules: true
-    :tag: v0.0.6
   OutputDescriptors:
     :git: https://github.com/sjors/output-descriptors-swift.git
     :tag: v0.0.2
 
 SPEC CHECKSUMS:
-  LibWally: 8192c453746bd8f86978c857aadef57477decbcc
+  LibWally: ce1e98813b64aa26b4cc3a92d3c7f57db97b2fb2
   OutputDescriptors: 700e55b31d3997fb2bf6d9d84f6172ac17a3d573
 
-PODFILE CHECKSUM: b4a77b28bc7832e680c78bba3eac23a48a0ccfa2
+PODFILE CHECKSUM: a0e48a29555f939bd4d5eeb5736f69b7e767872c
 
-COCOAPODS: 1.10.0
+COCOAPODS: 1.11.3


### PR DESCRIPTION
Bump version in CocoaPod.

- [ ] switch cocoapod from Jurvis' branch to tag
- [ ] test changes related to https://github.com/Sjors/libwally-swift/pull/68

-----
This ~currently fails~ used to fail:

```
...

checking for byteswap.h,... no
checking for sys/mman.h... yes
checking how to run the C preprocessor... /lib/cpp
configure: error: in `/Users/sjors/Library/Caches/CocoaPods/Pods/External/LibWally/133560e0df26601ba0de16cd99c01368/CLibWally/libwally-core':
configure: error: C preprocessor "/lib/cpp" fails sanity check
See `config.log' for more details

2022-05-01 17:59:05.607 xcodebuild[62912:5177277] Requested but did not find extension point with identifier Xcode.IDEKit.ExtensionSentinelHostApplications for extension Xcode.DebuggerFoundation.AppExtensionHosts.watchOS of plug-in com.apple.dt.IDEWatchSupportCore
2022-05-01 17:59:05.607 xcodebuild[62912:5177277] Requested but did not find extension point with identifier Xcode.IDEKit.ExtensionPointIdentifierToBundleIdentifier for extension Xcode.DebuggerFoundation.AppExtensionToBundleIdentifierMap.watchOS of plug-in com.apple.dt.IDEWatchSupportCore
2022-05-01 18:00:27.992 xcodebuild[71910:5192030] Requested but did not find extension point with identifier Xcode.IDEKit.ExtensionSentinelHostApplications for extension Xcode.DebuggerFoundation.AppExtensionHosts.watchOS of plug-in com.apple.dt.IDEWatchSupportCore
2022-05-01 18:00:27.993 xcodebuild[71910:5192030] Requested but did not find extension point with identifier Xcode.IDEKit.ExtensionPointIdentifierToBundleIdentifier for extension Xcode.DebuggerFoundation.AppExtensionToBundleIdentifierMap.watchOS of plug-in com.apple.dt.IDEWatchSupportCore
** ARCHIVE FAILED **


The following build commands failed:
	ExternalBuildToolExecution LibWallyCore (in target 'LibWallyCore' from project 'LibWally')
(1 failure)

```